### PR TITLE
Suggestions for ElementNotFoundError

### DIFF
--- a/spec/lucky_flow_spec.cr
+++ b/spec/lucky_flow_spec.cr
@@ -16,6 +16,14 @@ describe LuckyFlow do
     flow.el("@heading").text.should eq "Home"
   end
 
+  it "gives a recommendation if element not found" do
+    flow = visit_page_with "<span flow-id='heading'>Home</span>"
+
+    expect_raises LuckyFlow::ElementNotFoundError, "@heading" do
+      flow.el("@harding").displayed?
+    end
+  end
+
   it "can find a flow id" do
     flow = visit_page_with "<h1 flow-id='test-me'>Hello</h1>"
     flow.el("@test-me", text: "Hello").should be_on_page

--- a/src/lucky_flow/error_message_when_not_found.cr
+++ b/src/lucky_flow/error_message_when_not_found.cr
@@ -1,6 +1,7 @@
 class LuckyFlow
   class ErrorMessageWhenNotFound
-    def self.build(selector : String, inner_text : String?, negate : Bool = false)
+    def self.build(selector : String, inner_text : String?, helper : String? =
+                   nil, negate : Bool = false)
       String.build do |message|
         message << "Expected "
         message << "not " if negate
@@ -8,6 +9,12 @@ class LuckyFlow
         message << "not " unless negate
         message << "found."
         message << "\n\n  ▸ looking for: #{selector}"
+        if helper
+          message << "\n\n"
+          message << " Did you mean..."
+          message << "\n\n  ▸ "
+          message << "'@#{helper}'\n"
+        end
         unless (inner_text || "").empty?
           message << "\n  ▸ with text: #{inner_text}"
         end

--- a/src/lucky_flow/errors.cr
+++ b/src/lucky_flow/errors.cr
@@ -6,8 +6,9 @@ class LuckyFlow
   end
 
   class ElementNotFoundError < Error
-    def initialize(selector : String, inner_text : String?)
-      super LuckyFlow::ErrorMessageWhenNotFound.build(selector, inner_text)
+    def initialize(selector : String, inner_text : String?, helper : String?)
+      super LuckyFlow::ErrorMessageWhenNotFound.build(selector, inner_text,
+                                                      helper)
     end
   end
 end

--- a/src/lucky_flow/find_element.cr
+++ b/src/lucky_flow/find_element.cr
@@ -1,3 +1,5 @@
+require "levenshtein"
+
 # Find element on a page with a retry
 class LuckyFlow::FindElement
   property tries : Int32 = 0
@@ -45,7 +47,8 @@ class LuckyFlow::FindElement
   end
 
   private def raise_element_not_found_error
-    raise LuckyFlow::ElementNotFoundError.new(selector: selector, inner_text: inner_text)
+    raise LuckyFlow::ElementNotFoundError.new(selector: selector, inner_text:
+                                              inner_text, helper: nearest_match)
   end
 
   private def matching_elements : Array(Selenium::WebElement)
@@ -57,5 +60,13 @@ class LuckyFlow::FindElement
         true
       end
     end
+  end
+
+  private def all_elements  : Array(String)
+    session.find_elements(:css, "[flow-id]").map(&.attribute("flow-id")).uniq
+  end
+
+  private def nearest_match : String?
+    best_match = Levenshtein::Finder.find selector, all_elements, tolerance: 15
   end
 end


### PR DESCRIPTION
PR for #24 - if an element with `n` flow-id can't be found on a page, we
search the page for the rest of the flow-id elements and find the one
with the name that most closely matches and offer it as a suggesting in
the error text.