### PR TITLE
Do not spawn the shell when run the chromedriver in Linux

### DIFF
--- a/src/lucky_flow/chromedriver.cr
+++ b/src/lucky_flow/chromedriver.cr
@@ -19,8 +19,16 @@ class LuckyFlow::Chromedriver
       ["--port=4444", "--url-base=/wd/hub"],
       output: log_io,
       error: STDERR,
-      shell: true
+      shell: spawn_in_shell?
     )
+  end
+
+  private def spawn_in_shell?
+    {% if flag?(:linux) %}
+      false
+    {% else %}
+      true
+    {% end %}
   end
 
   private def os


### PR DESCRIPTION
Currently under linux when called Process.kill there remains orphan
child(only shell killed). On macos this does not happend.

I was tried to call kill with negative process pid(as was suggested in https://stackoverflow.com/questions/8533377/why-child-process-still-alive-after-parent-process-was-killed-in-linux), but in my os(`Linux 4.13.0-45-generic #50~16.04.1-Ubuntu SMP Wed May 30 11:18:27 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux`) this does not work.

example under linux
```
$ crystal spec
.........

Finished in 1.77 seconds
9 examples, 0 failures, 0 errors, 0 pending
$ ps auxf | grep lucky
dmitry    5474  0.0  0.0  15444  1008 pts/21   S+   18:20   0:00      \_ grep --color=auto lucky
dmitry    5208  2.3  0.0 109312 11716 pts/21   Sl   18:20   0:00 /home/dmitry/src/github.com/luckyframework/lucky
or/chromedriver-2.40-linux64 --port=4444 --url-base=/wd/hub
dmitry@xps-13:~/src/github.com/luckyframework/lucky_flow (do-not-spawn-shell-for-chromedriver)
$ crystal spec

Finished in 1.61 milliseconds
0 examples, 0 failures, 0 errors, 0 pending
Unhandled exception: bind: Address already in use (Errno)
  from /usr/share/crystal/src/socket/tcp_server.cr:73:15 in 'initialize'
  from /usr/share/crystal/src/socket/tcp_server.cr:32:3 in 'initialize:reuse_port'
  from /usr/share/crystal/src/socket/tcp_server.cr:32:3 in 'new:reuse_port'
  from /usr/share/crystal/src/http/server.cr:142:5 in 'bind_tcp'
  from /usr/share/crystal/src/http/server.cr:160:5 in 'bind_tcp:port'
  from spec/support/test_server.cr:15:5 in 'initialize'
  from spec/support/test_server.cr:5:3 in 'new'
  from spec/spec_helper.cr:8:1 in '__crystal_main'
  from /usr/share/crystal/src/crystal/main.cr:104:5 in 'main_user_code'
  from /usr/share/crystal/src/crystal/main.cr:93:7 in 'main'
  from /usr/share/crystal/src/crystal/main.cr:133:3 in 'main'
  from __libc_start_main
  from _start
  from ???

```