### PR TITLE
Moving Lucky specific stuff to separate module. Fixes #20

### DIFF
--- a/spec/lucky_flow_lucky_integration_spec.cr
+++ b/spec/lucky_flow_lucky_integration_spec.cr
@@ -1,0 +1,30 @@
+{% if flag?("include-lucky") %}
+require "./spec_helper"
+
+# mock the Lucky classes so we don't have to include the entire framework
+class Lucky::RouteHelper
+  def initialize(@path : String); end
+  def url
+    [LuckyFlow.settings.base_uri, @path].join
+  end
+end
+abstract class Lucky::Action; end
+class Users::Index < Lucky::Action
+  def self.route
+    Lucky::RouteHelper.new("/users")
+  end
+end
+class User; end
+
+describe "Lucky Integrations" do
+  it "can visit a URL with a Lucky::Action" do
+    TestServer.route "/users", "<span flow-id='heading'>Users</span>"
+    flow = LuckyFlow.new
+
+    flow.visit(Users::Index)
+
+    flow.el("@heading", text: "Users").should be_on_page
+  end
+end
+
+{% end %}

--- a/src/lucky_flow.cr
+++ b/src/lucky_flow.cr
@@ -8,6 +8,7 @@ require "file_utils"
 
 class LuckyFlow
   include LuckyFlow::Expectations
+  include LuckyFlow::LuckyHelpers
   SERVER = LuckyFlow::Server::INSTANCE
 
   Habitat.create do
@@ -19,21 +20,6 @@ class LuckyFlow
 
   def visit(path : String)
     session.url = "#{settings.base_uri}#{path}"
-  end
-
-  def visit(action : Lucky::Action.class, as user : User? = nil)
-    visit(action.route, as: user)
-  end
-
-  def visit(route_helper : Lucky::RouteHelper, as user : User? = nil)
-    url = route_helper.url
-    uri = URI.parse(url)
-    if uri.query && user
-      url += "&backdoor_user_id=#{user.id}"
-    elsif uri.query.nil? && user
-      url += "?backdoor_user_id=#{user.id}"
-    end
-    session.url = url
   end
 
   def open_screenshot(process = Process, time = Time.now) : Void
@@ -54,24 +40,6 @@ class LuckyFlow
 
   def fill(name_attr : String, with value : String)
     field(name_attr).fill(value)
-  end
-
-  # Fill a form created by Lucky that uses a LuckyRecord::Form
-  #
-  # Note that Lucky and LuckyRecord are required to use this method
-  #
-  # ```
-  # fill_form QuestionForm,
-  #   title: "Hello there!",
-  #   body: "Just wondering what day it is"
-  # ```
-  def fill_form(
-    form : LuckyRecord::Form.class | LuckyRecord::VirtualForm.class,
-    **fields_and_values
-  )
-    fields_and_values.each do |name, value|
-      fill "#{form.new.form_name}:#{name}", with: value
-    end
   end
 
   def el(css_selector : String, text : String)

--- a/src/lucky_flow/lucky_helpers.cr
+++ b/src/lucky_flow/lucky_helpers.cr
@@ -1,0 +1,39 @@
+class LuckyFlow
+  # These are helpers that are specific to Lucky applications
+  # 
+  module LuckyHelpers
+    def visit(action : Lucky::Action.class, as user : User? = nil)
+      visit(action.route, as: user)
+    end
+
+    def visit(route_helper : Lucky::RouteHelper, as user : User? = nil)
+      url = route_helper.url
+      uri = URI.parse(url)
+      if uri.query && user
+        url += "&backdoor_user_id=#{user.id}"
+      elsif uri.query.nil? && user
+        url += "?backdoor_user_id=#{user.id}"
+      end
+      session.url = url
+    end
+  
+    # Fill a form created by Lucky that uses a LuckyRecord::Form
+    #
+    # Note that Lucky and LuckyRecord are required to use this method
+    #
+    # ```
+    # fill_form QuestionForm,
+    #   title: "Hello there!",
+    #   body: "Just wondering what day it is"
+    # ```
+    def fill_form(
+      form : LuckyRecord::Form.class | LuckyRecord::VirtualForm.class,
+      **fields_and_values
+    )
+      fields_and_values.each do |name, value|
+        fill "#{form.new.form_name}:#{name}", with: value
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
All Lucky specific methods are moved to a separate module and included. Interesting thing, there were no specs calling these before. Apparently crystal doesn't care about class names in arguments unless those methods are actually called! Who knew? 

Anyway, this adds a spec that calls them, but since this library doesn't actually require lucky as a dependency, all of the classes had to be stubbed out. The lucky specific spec only runs when adding the `-D include-lucky` flag.

```
$ crystal spec/
.........

Finished in 2.24 seconds
9 examples, 0 failures, 0 errors, 0 pending

$ crystal spec/ -D include-lucky
..........

Finished in 2.36 seconds
10 examples, 0 failures, 0 errors, 0 pending
```