### PR TITLE
add custom chromedriver path setting. Fixes #5

### DIFF
--- a/src/lucky_flow.cr
+++ b/src/lucky_flow.cr
@@ -15,6 +15,7 @@ class LuckyFlow
     setting base_uri : String
     setting retry_delay : Time::Span = 10.milliseconds
     setting stop_retrying_after : Time::Span = 1.second
+    setting chromedriver_path : String? = nil
   end
 
   def visit(path : String)

--- a/src/lucky_flow/chromedriver.cr
+++ b/src/lucky_flow/chromedriver.cr
@@ -14,8 +14,9 @@ class LuckyFlow::Chromedriver
   end
 
   private def start_chromedriver : Process
+    driver_path = LuckyFlow.settings.chromedriver_path || "#{__DIR__}/../../vendor/chromedriver-2.40-#{os}"
     Process.new(
-      "#{__DIR__}/../../vendor/chromedriver-2.40-#{os}",
+      driver_path.as(String),
       ["--port=4444", "--url-base=/wd/hub"],
       output: log_io,
       error: STDERR,


### PR DESCRIPTION
Now you can set a custom path for your chromedriver. I'm not really sure how to test this yet. I'm thinking something like

```crystal
LuckyFlow.temp_config(chromedriver_path: "/path/to/fake/driver") do
  driver = LuckyFlow::Chromedriver.new
  driver.log_io.should eq ""
end
```

I don't know that it's helpful at all, but it would test that nothing breaks, I guess 🤷‍♂️ 