### PR TITLE
Get form name from class method

### DIFF
--- a/src/lucky_flow.cr
+++ b/src/lucky_flow.cr
@@ -90,7 +90,7 @@ class LuckyFlow
     **fields_and_values
   )
     fields_and_values.each do |name, value|
-      fill "#{form.new.form_name}:#{name}", with: value
+      fill "#{form.form_name}:#{name}", with: value
     end
   end
 


### PR DESCRIPTION
When using the fill_form method, the form's name is retrieved to help in filling out form fields with values.

The name was being fetched with `form.new.name`. However, in the case that a form has a `needs`, it will add that that to the list of required variables to pass in an initializer. This throws a compilation error when running the aforementioned `form.new.name`.

Instead, we can use the form.form_name class method to get the name necessary. Currently in lucky record, the method returns the class's name anyway:

```crystal
def form_name
  self.class.form_name
end
```

Now fields with any amount of initializers from 0 to infinite will be able to fetch their name for the form.