### PR TITLE
Prefer system chromedriver if installed

### DIFF
--- a/src/lucky_flow/chromedriver.cr
+++ b/src/lucky_flow/chromedriver.cr
@@ -14,7 +14,9 @@ class LuckyFlow::Chromedriver
   end
 
   private def start_chromedriver : Process
-    driver_path = LuckyFlow.settings.chromedriver_path || "#{__DIR__}/../../vendor/chromedriver-74-#{os}"
+    driver_path = LuckyFlow.settings.chromedriver_path ||
+                  Process.find_executable("chromedriver") ||
+                  "#{__DIR__}/../../vendor/chromedriver-74-#{os}"
     Process.new(
       driver_path.as(String),
       ["--port=4444", "--url-base=/wd/hub"],


### PR DESCRIPTION
Part of #44

Previously we used the vendored chromedriver if one was not explicitly
set. Instead we use the system chromedriver before the vendored one.
That way if someone has chromedriver installed we use that.