### PR TITLE
Add support for browser binary setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ LuckyFlow.configure do
   settings.retry_delay = 10.milliseconds
   settings.stop_retrying_after = 1.second
   settings.screenshot_directory = "./tmp/screenshots"
+  settings.browser_binary = "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"
 end
 
 # Put this at the bottom of the file.

--- a/src/lucky_flow.cr
+++ b/src/lucky_flow.cr
@@ -16,6 +16,7 @@ class LuckyFlow
     setting retry_delay : Time::Span = 10.milliseconds
     setting stop_retrying_after : Time::Span = 1.second
     setting chromedriver_path : String? = nil
+    setting browser_binary : String? = nil
   end
 
   def visit(path : String)

--- a/src/lucky_flow/server.cr
+++ b/src/lucky_flow/server.cr
@@ -43,7 +43,7 @@ class LuckyFlow::Server
 
   private def start_session
     driver = Selenium::Webdriver.new
-    Selenium::Session.new(driver, CAPABILITIES)
+    Selenium::Session.new(driver, capabilities)
   rescue e : Errno
     retry_start_session(e)
   end
@@ -64,6 +64,23 @@ class LuckyFlow::Server
 
   private def screenshot_directory
     LuckyFlow.settings.screenshot_directory
+  end
+
+  private def browser_binary
+    LuckyFlow.settings.browser_binary
+  end
+
+  private def capabilities
+    if browser_binary.nil?
+      CAPABILITIES
+    else
+      CAPABILITIES.merge({
+        chromeOptions: {
+          args:   CAPABILITIES[:chromeOptions][:args],
+          binary: browser_binary,
+        },
+      })
+    end
   end
 
   private def start_chromedriver


### PR DESCRIPTION
This PR makes it possible to use another chromium-based browser instead of Google Chrome.

At the moment `#capabilities` is called often and we could avoid merging the settings every time `start_session` is called.

I'm opening this PR to see how we would like to handle this properly.