### PR TITLE
[WIP] Add within capability

### DIFF
--- a/spec/lucky_flow_spec.cr
+++ b/spec/lucky_flow_spec.cr
@@ -142,7 +142,7 @@ describe LuckyFlow do
         </li>
       </ul>
     HTML
-  
+
     flow.within("@item-1") do |item_flow|
       item_flow.el("@text", text: "Item 1").should be_on_page
       item_flow.click("@target")

--- a/spec/lucky_flow_spec.cr
+++ b/spec/lucky_flow_spec.cr
@@ -128,6 +128,29 @@ describe LuckyFlow do
     flow.el("h1", text: "Target").should be_on_page
   end
 
+  it "can find an element within another element" do
+    TestServer.route "/target", "<h1>Target</h1>"
+    flow = visit_page_with <<-HTML
+      <ul>
+        <li flow-id="item-0">
+          <p flow-id="text">Item 0</p>
+          <a flow-id='target' href='/error'>Click Me</a>
+        </li>
+        <li flow-id="item-1">
+          <p flow-id="text">Item 1</p>
+          <a flow-id='target' href='/target'>Click Me</a>
+        </li>
+      </ul>
+    HTML
+  
+    flow.within("@item-1") do |item_flow|
+      item_flow.el("@text", text: "Item 1").should be_on_page
+      item_flow.click("@target")
+    end
+
+    flow.el("h1", text: "Target").should be_on_page
+  end
+
   it "can open screenshots" do
     flow = LuckyFlow.new
     fake_process = FakeProcess

--- a/src/lucky_flow.cr
+++ b/src/lucky_flow.cr
@@ -19,6 +19,11 @@ class LuckyFlow
     setting browser_binary : String? = nil
   end
 
+  private getter parent
+
+  def initialize(@parent : Element? = nil)
+  end
+
   def visit(path : String)
     session.url = "#{settings.base_uri}#{path}"
   end
@@ -120,15 +125,19 @@ class LuckyFlow
   end
 
   def el(css_selector : String, text : String)
-    Element.new(css_selector, text)
+    Element.new(css_selector, text, parent)
   end
 
   def el(css_selector : String)
-    Element.new(css_selector)
+    Element.new(css_selector, parent: parent)
   end
 
   def field(name_attr : String)
-    Element.new("[name='#{name_attr}']")
+    Element.new("[name='#{name_attr}']", parent: parent)
+  end
+
+  def within(css_selector : String)
+    yield(self.class.new(parent: Element.new(css_selector, parent: parent)))
   end
 
   def session

--- a/src/lucky_flow/element.cr
+++ b/src/lucky_flow/element.cr
@@ -1,16 +1,16 @@
 class LuckyFlow::Element
   private getter raw_selector
-  getter inner_text
+  getter inner_text, parent
   delegate text, click, send_keys, displayed?, attribute, to: element
   delegate session, to: LuckyFlow
 
-  def initialize(@raw_selector : String, text @inner_text : String? = nil)
+  def initialize(@raw_selector : String, text @inner_text : String? = nil, @parent : Element? = nil)
   end
 
   @_element : Selenium::WebElement?
 
-  private def element : Selenium::WebElement
-    @_element ||= FindElement.run(session, selector, inner_text)
+  def element : Selenium::WebElement
+    @_element ||= FindElement.run(session, selector, inner_text, parent)
   end
 
   def value

--- a/src/lucky_flow/find_element.cr
+++ b/src/lucky_flow/find_element.cr
@@ -9,7 +9,8 @@ class LuckyFlow::FindElement
     @session : Selenium::Session,
     @selector : String,
     text @inner_text : String? = nil,
-    @parent : Element? = nil)
+    @parent : Element? = nil
+  )
   end
 
   def self.run(*args, **named_args)

--- a/src/lucky_flow/find_element.cr
+++ b/src/lucky_flow/find_element.cr
@@ -3,9 +3,13 @@ require "levenshtein"
 # Find element on a page with a retry
 class LuckyFlow::FindElement
   property tries : Int32 = 0
-  private getter session, selector, inner_text
+  private getter session, selector, inner_text, parent
 
-  def initialize(@session : Selenium::Session, @selector : String, text @inner_text : String? = nil)
+  def initialize(
+    @session : Selenium::Session,
+    @selector : String,
+    text @inner_text : String? = nil,
+    @parent : Element? = nil)
   end
 
   def self.run(*args, **named_args)
@@ -47,7 +51,7 @@ class LuckyFlow::FindElement
   end
 
   private def matching_elements : Array(Selenium::WebElement)
-    session.find_elements(:css, selector).select do |element|
+    session.find_elements(:css, selector, parent_element).select do |element|
       text_to_check_for = inner_text
       if text_to_check_for
         element.text.includes?(text_to_check_for)
@@ -62,5 +66,9 @@ class LuckyFlow::FindElement
       selector: selector,
       inner_text: inner_text
     )
+  end
+
+  private def parent_element : Selenium::WebElement?
+    parent.try &.element
   end
 end


### PR DESCRIPTION
## The Problem

Especially in circumstances where one is working with lists, it can cause struggles trying to pass around a unique identifier to all the elements that are needing to be tested. A scenario might be that the app is a todo list and the tester is trying to target the 3rd item in the list and click the complete button. The current solution for that is to map over the list of todos with an index and pass that index down into the button definition so that a unique flow id can be set.

<details>
  <summary>Example HTML</summary>
  
 ```html
<ul>
  <li flow-id="todo-0">Cook <button flow-id="todo-complete-0">Complete</button></li>
  <li flow-id="todo-1">Run <button flow-id="todo-complete-1">Complete</button></li>
  <li flow-id="todo-2">Take out trash <button flow-id="todo-complete-2">Complete</button></li>
</ul>
```
</details>

## The Solution

`Lucky::Flow#within` allows users to target a wrapping div so that they can narrow down the scope of the targets that are available to be selected. In the above todo app example, the only unique place a unique identifier would have to be placed is on the `<li>` tag and then generic identifiers could be used inside it.

<details>
  <summary>Example HTML</summary>
  
```html
<ul>
  <li flow-id="todo-0">Cook <button flow-id="todo-complete">Complete</button></li>
  <li flow-id="todo-1">Run <button flow-id="todo-complete">Complete</button></li>
  <li flow-id="todo-2">Take out trash <button flow-id="todo-complete">Complete</button></li>
</ul>
```
</details>

## Usage

This was definitely inspired by capybara's within method. With capybara, you can continue using the same methods inside it, but that is not the case here. When you call `within` you are given a new flow to call methods on.

```crystal
it "can be completed" do
  flow = BaseFlow.new

  flow.within "@todo-2" do |todo_flow|
    todo_flow.click("@todo-complete")
  end
end
```

## Current Issues

This is just a list of things that I need help with and/or I anticipate will keep this from getting merged.

- This is a breaking change since I am implementing the `#initialize` method
- I'm not sure that I am creating the right class inside the `#within` method.
  - In lucky apps, `Lucky::Flow` is extended by `BaseFlow` and I don't know if this will new up that class or whatever child class is being used.
- I've seen at least one bug from this: https://github.com/ysbaddaden/selenium-webdriver-crystal/issues/41
- There are definitely other tests to write