### PR TITLE
Switch selenium libraries

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -10,8 +10,8 @@ license: MIT
 
 dependencies:
   selenium:
-    github: ysbaddaden/selenium-webdriver-crystal
-    commit: bda2fd406c1a118251c5a2883f1e1f3af242116e
+    github: matthewmcgarvey/selenium.cr
+    version: ~> 0.4.0
   habitat:
     github: luckyframework/habitat
     version: ~> 0.4.0

--- a/spec/lucky_flow_spec.cr
+++ b/spec/lucky_flow_spec.cr
@@ -152,13 +152,13 @@ describe LuckyFlow do
 
   it "can reset the session" do
     flow = LuckyFlow.new
-    flow.session.cookies.set("hello", "world")
-    flow.session.cookies.get("hello").value.should eq "world"
+    flow.session.cookie_manager.add_cookie("hello", "world")
+    flow.session.cookie_manager.get_cookie("hello").value.should eq "world"
 
     LuckyFlow.reset
 
-    expect_raises KeyError do
-      flow.session.cookies.get("hello").value
+    expect_raises Selenium::Error do
+      flow.session.cookie_manager.get_cookie("hello").value
     end
   end
 end

--- a/src/lucky_flow.cr
+++ b/src/lucky_flow.cr
@@ -20,7 +20,7 @@ class LuckyFlow
   end
 
   def visit(path : String)
-    session.url = "#{settings.base_uri}#{path}"
+    session.navigate_to("#{settings.base_uri}#{path}")
   end
 
   def visit(action : Lucky::Action.class, as user : User? = nil)
@@ -46,9 +46,9 @@ class LuckyFlow
 
   def take_screenshot(filename : String = generate_screenshot_filename, fullsize : Bool = true)
     if fullsize
-      with_fullsized_page { session.save_screenshot(filename) }
+      with_fullsized_page { session.screenshot(filename) }
     else
-      session.save_screenshot(filename)
+      session.screenshot(filename)
     end
   end
 
@@ -57,18 +57,17 @@ class LuckyFlow
   end
 
   def expand_page_to_fullsize
-    width = session.execute("return Math.max(document.body.scrollWidth, document.body.offsetWidth, document.documentElement.clientWidth, document.documentElement.scrollWidth, document.documentElement.offsetWidth);").as_i
-    height = session.execute("return Math.max(document.body.scrollHeight, document.body.offsetHeight, document.documentElement.clientHeight, document.documentElement.scrollHeight, document.documentElement.offsetHeight);").as_i
-    window = session.window
-    window.resize_to(width + 100, height + 100)
+    width = session.document_manager.execute_script("return Math.max(document.body.scrollWidth, document.body.offsetWidth, document.documentElement.clientWidth, document.documentElement.scrollWidth, document.documentElement.offsetWidth);").to_i64
+    height = session.document_manager.execute_script("return Math.max(document.body.scrollHeight, document.body.offsetHeight, document.documentElement.clientHeight, document.documentElement.scrollHeight, document.documentElement.offsetHeight);").to_i64
+    session.window_manager.resize_window(width: width + 100, height: height + 100)
   end
 
   def with_fullsized_page(&block)
-    original_size = session.window.rect
+    original_size = session.window_manager.window_rect
     expand_page_to_fullsize
     yield
   ensure
-    session.window.rect = original_size
+    session.window_manager.set_window_rect(original_size)
   end
 
   private def open_command(process) : String

--- a/src/lucky_flow/element.cr
+++ b/src/lucky_flow/element.cr
@@ -7,9 +7,9 @@ class LuckyFlow::Element
   def initialize(@raw_selector : String, text @inner_text : String? = nil)
   end
 
-  @_element : Selenium::WebElement?
+  @_element : Selenium::Element?
 
-  private def element : Selenium::WebElement
+  private def element : Selenium::Element
     @_element ||= FindElement.run(session, selector, inner_text)
   end
 

--- a/src/lucky_flow/find_element.cr
+++ b/src/lucky_flow/find_element.cr
@@ -46,7 +46,7 @@ class LuckyFlow::FindElement
     LuckyFlow.settings
   end
 
-  private def matching_elements : Array(Selenium::WebElement)
+  private def matching_elements : Array(Selenium::Element)
     session.find_elements(:css, selector).select do |element|
       text_to_check_for = inner_text
       if text_to_check_for
@@ -55,6 +55,8 @@ class LuckyFlow::FindElement
         true
       end
     end
+  rescue Selenium::Error
+    [] of Selenium::Element
   end
 
   private def raise_element_not_found_error


### PR DESCRIPTION
Fixes #75

Moving to https://github.com/matthewmcgarvey/selenium.cr

The previous selenium library was made to support the obsolete JsonWireProtocol which is not guaranteed to be followed by browsers. Moving to the W3C standard which this new library supports gives greater compatibility to browsers as it is the standard all the main selenium libraries use.

This also gives lucky_flow the potential to be used to test against more than just Chrome.