### PR TITLE
[broken spec] Can only set cookies on a page

### DIFF
--- a/spec/lucky_flow_spec.cr
+++ b/spec/lucky_flow_spec.cr
@@ -162,7 +162,9 @@ describe LuckyFlow do
   end
 
   it "can reset the session" do
-    flow = LuckyFlow.new
+    flow = visit_page_with <<-HTML
+      <h1>Title</h1>
+    HTML
     flow.session.cookie_manager.add_cookie("hello", "world")
     flow.session.cookie_manager.get_cookie("hello").value.should eq "world"
 


### PR DESCRIPTION
This spec was not failing normally because the driver had an open session from a previous spec. Running it by itself fails.