### PR TITLE
Replace recursion with loop in FindElement#run

### DIFF
--- a/src/lucky_flow/find_element.cr
+++ b/src/lucky_flow/find_element.cr
@@ -13,29 +13,21 @@ class LuckyFlow::FindElement
   end
 
   def run
-    matching_elements.first? || retry
-  end
-
-  private def retry
-    self.tries += 1
-    if has_retries_left?
-      retry_after_delay
-    else
-      raise_element_not_found_error
+    while has_retries_left?
+      matching_elements = find_matching_elements
+      return matching_elements.first if matching_elements.first?
+      sleep retry_delay_in_ms
     end
+    raise_element_not_found_error
   end
 
   private def has_retries_left?
     tries < max_tries
   end
 
-  private def retry_after_delay
-    sleep retry_delay_in_ms
-    run
-  end
-
   private def max_tries : Int32
-    (settings.stop_retrying_after / settings.retry_delay).to_i
+    max_tries = (settings.stop_retrying_after / settings.retry_delay).to_i
+    max_tries > 0 ? max_tries : 1
   end
 
   private def retry_delay_in_ms : Float
@@ -46,7 +38,8 @@ class LuckyFlow::FindElement
     LuckyFlow.settings
   end
 
-  private def matching_elements : Array(Selenium::Element)
+  private def find_matching_elements : Array(Selenium::Element)
+    self.tries += 1
     session.find_elements(:css, selector).select do |element|
       text_to_check_for = inner_text
       if text_to_check_for

--- a/src/lucky_flow/find_element.cr
+++ b/src/lucky_flow/find_element.cr
@@ -13,11 +13,14 @@ class LuckyFlow::FindElement
   end
 
   def run
-    while has_retries_left?
+    loop do
       matching_elements = find_matching_elements
       return matching_elements.first if matching_elements.first?
+
+      break unless has_retries_left?
       sleep retry_delay_in_ms
     end
+
     raise_element_not_found_error
   end
 
@@ -26,8 +29,7 @@ class LuckyFlow::FindElement
   end
 
   private def max_tries : Int32
-    max_tries = (settings.stop_retrying_after / settings.retry_delay).to_i
-    max_tries > 0 ? max_tries : 1
+    (settings.stop_retrying_after / settings.retry_delay).to_i
   end
 
   private def retry_delay_in_ms : Float


### PR DESCRIPTION
Fixes #78 

This drastically simplifies the stack trace when a spec attempts to find an element and fails.

### Before

```
Expected to find element on page, but it was not found.
       
  ▸ looking for: [flow-id='sign-up-buttons']

Did you mean...

  ▸ '@sign-up-button'
(LuckyFlow::ElementNotFoundError)
  from lib/lucky_flow/src/lucky_flow/find_element.cr:61:5 in 'raise_element_not_found_error'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:24:7 in 'retry'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:16:33 in 'run'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:34:5 in 'retry_after_delay'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:22:7 in 'retry'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:16:33 in 'run'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:34:5 in 'retry_after_delay'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:22:7 in 'retry'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:16:33 in 'run'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:34:5 in 'retry_after_delay'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:22:7 in 'retry'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:16:33 in 'run'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:34:5 in 'retry_after_delay'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:22:7 in 'retry'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:16:33 in 'run'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:34:5 in 'retry_after_delay'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:22:7 in 'retry'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:16:33 in 'run'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:34:5 in 'retry_after_delay'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:22:7 in 'retry'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:16:33 in 'run'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:34:5 in 'retry_after_delay'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:22:7 in 'retry'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:16:33 in 'run'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:34:5 in 'retry_after_delay'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:22:7 in 'retry'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:16:33 in 'run'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:34:5 in 'retry_after_delay'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:22:7 in 'retry'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:16:33 in 'run'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:34:5 in 'retry_after_delay'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:22:7 in 'retry'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:16:33 in 'run'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:34:5 in 'retry_after_delay'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:22:7 in 'retry'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:16:33 in 'run'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:34:5 in 'retry_after_delay'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:22:7 in 'retry'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:16:33 in 'run'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:34:5 in 'retry_after_delay'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:22:7 in 'retry'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:16:33 in 'run'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:34:5 in 'retry_after_delay'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:22:7 in 'retry'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:16:33 in 'run'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:34:5 in 'retry_after_delay'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:22:7 in 'retry'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:16:33 in 'run'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:34:5 in 'retry_after_delay'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:22:7 in 'retry'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:16:33 in 'run'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:34:5 in 'retry_after_delay'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:22:7 in 'retry'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:16:33 in 'run'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:34:5 in 'retry_after_delay'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:22:7 in 'retry'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:16:33 in 'run'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:34:5 in 'retry_after_delay'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:22:7 in 'retry'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:16:33 in 'run'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:12:5 in 'run'
  from lib/lucky_flow/src/lucky_flow/element.cr:13:19 in 'element'
  from lib/lucky_flow/src/lucky_flow/element.cr:4:3 in 'click'
  from lib/lucky_flow/src/lucky_flow.cr:81:5 in 'click'
  from spec/support/flows/authentication_flow.cr:13:5 in 'sign_up'
  from spec/flows/authentication_spec.cr:7:5 in '->'
  from /usr/local/Cellar/crystal/0.34.0/src/spec/example.cr:255:3 in 'internal_run'
  from /usr/local/Cellar/crystal/0.34.0/src/spec/example.cr:35:16 in 'run'
  from /usr/local/Cellar/crystal/0.34.0/src/spec/context.cr:296:23 in 'internal_run'
  from /usr/local/Cellar/crystal/0.34.0/src/spec/context.cr:291:7 in 'run'
  from /usr/local/Cellar/crystal/0.34.0/src/spec/context.cr:48:23 in 'run'
  from /usr/local/Cellar/crystal/0.34.0/src/spec/dsl.cr:270:7 in '->'
  from /usr/local/Cellar/crystal/0.34.0/src/crystal/at_exit_handlers.cr:255:3 in 'run'
  from /usr/local/Cellar/crystal/0.34.0/src/crystal/main.cr:45:14 in 'main'
  from /usr/local/Cellar/crystal/0.34.0/src/crystal/main.cr:114:3 in 'main'
```

### After

```
Expected to find element on page, but it was not found.
       
  ▸ looking for: [flow-id='sign-up-buttons']

Did you mean...

  ▸ '@sign-up-button'
(LuckyFlow::ElementNotFoundError)
  from lib/lucky_flow/src/lucky_flow/find_element.cr:56:5 in 'raise_element_not_found_error'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:18:41 in 'run'
  from lib/lucky_flow/src/lucky_flow/find_element.cr:12:5 in 'run'
  from lib/lucky_flow/src/lucky_flow/element.cr:13:19 in 'element'
  from lib/lucky_flow/src/lucky_flow/element.cr:4:3 in 'click'
  from lib/lucky_flow/src/lucky_flow.cr:81:5 in 'click'
  from spec/support/flows/authentication_flow.cr:13:5 in 'sign_up'
  from spec/flows/authentication_spec.cr:7:5 in '->'
  from /usr/local/Cellar/crystal/0.34.0/src/spec/example.cr:255:3 in 'internal_run'
  from /usr/local/Cellar/crystal/0.34.0/src/spec/example.cr:35:16 in 'run'
  from /usr/local/Cellar/crystal/0.34.0/src/spec/context.cr:296:23 in 'internal_run'
  from /usr/local/Cellar/crystal/0.34.0/src/spec/context.cr:291:7 in 'run'
  from /usr/local/Cellar/crystal/0.34.0/src/spec/context.cr:48:23 in 'run'
  from /usr/local/Cellar/crystal/0.34.0/src/spec/dsl.cr:270:7 in '->'
  from /usr/local/Cellar/crystal/0.34.0/src/crystal/at_exit_handlers.cr:255:3 in 'run'
  from /usr/local/Cellar/crystal/0.34.0/src/crystal/main.cr:45:14 in 'main'
  from /usr/local/Cellar/crystal/0.34.0/src/crystal/main.cr:114:3 in 'main'
```