### PR TITLE
LuckyFlow::Element#value uses property instead of attribute

### DIFF
--- a/src/lucky_flow/element.cr
+++ b/src/lucky_flow/element.cr
@@ -1,7 +1,7 @@
 class LuckyFlow::Element
   private getter raw_selector
   getter inner_text
-  delegate text, click, send_keys, displayed?, attribute, to: element
+  delegate text, click, send_keys, displayed?, attribute, property, to: element
   delegate session, to: LuckyFlow
 
   def initialize(@raw_selector : String, text @inner_text : String? = nil)
@@ -14,7 +14,7 @@ class LuckyFlow::Element
   end
 
   def value
-    attribute("value")
+    property("value")
   end
 
   # Set the text of a form field


### PR DESCRIPTION
The reasoning behind this was laid out here: https://github.com/luckyframework/lucky_flow/issues/86

TLDR: switching to `property` allows us to add support for other browsers in the future

Fixes #86 