### PR TITLE
Add expectation for the current path

### DIFF
--- a/spec/lucky_flow_spec.cr
+++ b/spec/lucky_flow_spec.cr
@@ -9,6 +9,7 @@ describe LuckyFlow do
 
     flow.el("@heading", text: "Home").should be_on_page
     flow.el("@heading").should have_text("Home")
+    flow.should have_current_path("/home")
   end
 
   it "can visit URL with backdoor" do

--- a/src/lucky_flow.cr
+++ b/src/lucky_flow.cr
@@ -131,6 +131,11 @@ class LuckyFlow
     Element.new("[name='#{name_attr}']")
   end
 
+  def current_path
+    url = session.current_url
+    URI.parse(url).path
+  end
+
   def session
     self.class.session
   end

--- a/src/lucky_flow/expectations.cr
+++ b/src/lucky_flow/expectations.cr
@@ -9,5 +9,17 @@ class LuckyFlow
     private def have_text(expected_text)
       HaveTextExpectation.new(expected_text)
     end
+
+    private def have_current_path(expected_path : String)
+      HaveCurrentPathExpectation.new(expected_path)
+    end
+
+    private def have_current_path(action : Lucky::Action.class)
+      have_current_path(action.route)
+    end
+
+    private def have_current_path(route_helper : Lucky::RouteHelper)
+      HaveCurrentPathExpectation.new(route_helper.path)
+    end
   end
 end

--- a/src/lucky_flow/expectations/have_current_path_expectation.cr
+++ b/src/lucky_flow/expectations/have_current_path_expectation.cr
@@ -1,0 +1,19 @@
+struct LuckyFlow::Expectations::HaveCurrentPathExpectation
+  def initialize(@expected_path : String)
+  end
+
+  def match(flow : LuckyFlow) : Bool
+    flow.current_path == @expected_path
+  end
+
+  def failure_message(flow)
+    <<-MSG
+    Expected current path to be: #{@expected_path}
+                         actual: #{flow.current_path}
+    MSG
+  end
+
+  def negative_failure_message(_flow)
+    "Expected current path not to be: #{@expected_path}"
+  end
+end


### PR DESCRIPTION
Fixes #94 

This allows us to write specs like
```crystal
it "requires signed in users" do
  flow = BaseFlow.new
  flow.visit Authenticated::Endpoint::Index
  flow.should have_current_path(SignIn::New)
end
```