### PR TITLE
HaveTextExpectation should assert element contains text

### DIFF
--- a/spec/lucky_flow/expectations/have_text_expectation_spec.cr
+++ b/spec/lucky_flow/expectations/have_text_expectation_spec.cr
@@ -22,6 +22,21 @@ module LuckyFlow::Expectations
 
         expectation.match(element).should be_false
       end
+
+      it "returns true if element contains text" do
+        element = LuckyFlow::Element.new(raw_selector: "@container")
+
+        visit_page_with <<-HTML
+          <div flow-id="container">
+            <h1>Hello, World!</h1>
+            <span>Welcome to the subheading</span>
+          </div>
+        HTML
+
+        expectation = HaveTextExpectation.new(expected_value: "Hello, World!")
+
+        expectation.match(element).should be_true
+      end
     end
 
     describe "#failure_message" do

--- a/src/lucky_flow/expectations/have_text_expectation.cr
+++ b/src/lucky_flow/expectations/have_text_expectation.cr
@@ -3,7 +3,7 @@ struct LuckyFlow::Expectations::HaveTextExpectation
   end
 
   def match(element)
-    element.text == @expected_value
+    element.text.includes? @expected_value
   end
 
   def failure_message(element)


### PR DESCRIPTION
Fixes https://github.com/luckyframework/lucky_flow/issues/98

Without using `includes?` we can't, for example, assert that a list of emails contains a specific one using this assertion.
It did work with `flow.el("@flow-id", text: "foo@example.com").should be_on_page` though.