### PR TITLE
Add automatic GitHub Pages documentation deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,24 @@
+name: Deploy docs
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    container:
+      image: crystallang/crystal
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - name: "Install shards"
+        run: shards install
+      - name: "Generate docs"
+        run: crystal docs
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # LuckyFlow
 
+[![API Documentation Website](https://img.shields.io/website?down_color=red&down_message=Offline&label=API%20Documentation&up_message=Online&url=https%3A%2F%2Fluckyframework.github.io%2Flucky_flow%2F)](https://luckyframework.github.io/lucky_flow)
+
 LuckyFlow is a library for testing user flows in the browser. It is similar to
 Ruby's Capybara.
 


### PR DESCRIPTION
This is part of a series of PRs to get all of our Lucky repositories auto-deploying API documentation to GitHub pages. Having these accessible will assist with the new "Learn" section on the website.

This PR contains two main elements:
- Add the GitHub Action to build documentation into the `gh-pages` branch
- Add a badge to the README linking to the API documentation