### PR TITLE
Can accept and dismiss alerts

### DIFF
--- a/spec/lucky_flow_spec.cr
+++ b/spec/lucky_flow_spec.cr
@@ -176,6 +176,26 @@ describe LuckyFlow do
       flow.session.cookie_manager.get_cookie("hello").value
     end
   end
+
+  it "can accept and dismiss alerts" do
+    flow = visit_page_with <<-HTML
+      <button onclick="createAlert()" flow-id="button" data-count="0">Click Me - 0</button>
+      <script>
+      function createAlert() {
+        alert("Are you sure?");
+        const button = document.querySelector("[flow-id='button']");
+        button.innerText = 'Click Me - ' + (++button.dataset.count);
+      }
+      </script>
+    HTML
+
+    flow.click("@button")
+    flow.accept_alert
+    flow.el("@button", text: "Click Me - 1").should be_on_page
+    flow.click("@button")
+    flow.dismiss_alert
+    flow.el("@button", text: "Click Me - 2").should be_on_page
+  end
 end
 
 private class FakeProcess

--- a/src/lucky_flow.cr
+++ b/src/lucky_flow.cr
@@ -136,6 +136,14 @@ class LuckyFlow
     URI.parse(url).path
   end
 
+  def accept_alert
+    session.alert_manager.accept_alert
+  end
+
+  def dismiss_alert
+    session.alert_manager.dismiss_alert
+  end
+
   def session
     self.class.session
   end


### PR DESCRIPTION
Fixes https://github.com/luckyframework/lucky_flow/issues/67

One thing I was surprised by is that you cannot take screenshots if an alert is present. Some selenium libraries might implement functionality around taking a screenshot of the "browser" instead of just the element/window to get around this.

https://stackoverflow.com/questions/47693245/how-can-i-take-a-screenshot-of-an-alert-using-selenium-webdriver-in-ruby
https://stackoverflow.com/questions/21670361/capture-screenshot-of-alert