### PR TITLE
Allow running Chrome headfully

### DIFF
--- a/src/lucky_flow/driver.cr
+++ b/src/lucky_flow/driver.cr
@@ -1,0 +1,14 @@
+abstract class LuckyFlow::Driver
+  @retry_limit : Time = 2.seconds.from_now
+
+  abstract def start_session : Selenium::Session
+
+  protected def retry_start_session(e)
+    if Time.utc <= @retry_limit
+      sleep(0.1)
+      start_session
+    else
+      raise e
+    end
+  end
+end

--- a/src/lucky_flow/drivers/chrome.cr
+++ b/src/lucky_flow/drivers/chrome.cr
@@ -1,0 +1,30 @@
+abstract class LuckyFlow::Drivers::Chrome < LuckyFlow::Driver
+  def start_session : Selenium::Session
+    driver.create_session(capabilities)
+  rescue e : IO::Error
+    retry_start_session(e)
+  end
+
+  def stop
+    driver.stop
+  end
+
+  protected def capabilities
+    Selenium::Chrome::Capabilities.new
+  end
+
+  @driver : Selenium::Driver?
+
+  private def driver : Selenium::Driver
+    @driver ||= begin
+      service = Selenium::Service.chrome(driver_path: driver_path)
+      Selenium::Driver.for(:chrome, service: service)
+    end
+  end
+
+  private def driver_path
+    LuckyFlow.settings.chromedriver_path || Webdrivers::Chromedriver.install
+  rescue err
+    raise DriverInstallationError.new(err)
+  end
+end

--- a/src/lucky_flow/drivers/chrome.cr
+++ b/src/lucky_flow/drivers/chrome.cr
@@ -6,7 +6,7 @@ abstract class LuckyFlow::Drivers::Chrome < LuckyFlow::Driver
   end
 
   def stop
-    driver.stop
+    @driver.try(&.stop)
   end
 
   protected def capabilities

--- a/src/lucky_flow/drivers/headless_chrome.cr
+++ b/src/lucky_flow/drivers/headless_chrome.cr
@@ -1,0 +1,8 @@
+class LuckyFlow::Drivers::HeadlessChrome < LuckyFlow::Drivers::Chrome
+  protected def capabilities
+    capabilities = super
+    capabilities.args(["no-sandbox", "headless", "disable-gpu"])
+
+    capabilities
+  end
+end

--- a/src/lucky_flow/server.cr
+++ b/src/lucky_flow/server.cr
@@ -3,56 +3,18 @@ class LuckyFlow::Server
   # This is used so that only one server instance is started
   INSTANCE = new
 
-  CAPABILITIES = Selenium::Chrome::Capabilities.new
-  CAPABILITIES.args(["no-sandbox", "headless", "disable-gpu"])
-
-  @retry_limit : Time?
   @session : Selenium::Session?
-  @driver : Selenium::Driver?
+  private getter driver : LuckyFlow::Driver = LuckyFlow::Drivers::HeadlessChrome.new
 
   # Use LuckyFlow::Server::INSTANCE instead
   private def initialize
   end
 
-  # Start a new selenium session with Chromedriver
+  # Start a new selenium session
   def session : Selenium::Session
-    @session ||= create_session
-  end
-
-  private def driver : Selenium::Driver
-    @driver ||= begin
-      service = Selenium::Service.chrome(driver_path: driver_path)
-      Selenium::Driver.for(:chrome, service: service)
-    end
-  end
-
-  private def create_session : Selenium::Session
-    @retry_limit = 2.seconds.from_now
-    prepare_screenshot_directory
-    start_session
-  end
-
-  # If less than 0.34.0
-  {% if compare_versions(Crystal::VERSION, "0.34.0") == -1 %}
-    private def start_session
-      driver.create_session(CAPABILITIES)
-    rescue e : Errno
-      retry_start_session(e)
-    end
-  {% else %}
-    private def start_session
-      driver.create_session(CAPABILITIES)
-    rescue e : IO::Error
-      retry_start_session(e)
-    end
-  {% end %}
-
-  private def retry_start_session(e)
-    if Time.utc <= @retry_limit.not_nil!
-      sleep(0.1)
-      start_session
-    else
-      raise e
+    @session ||= begin
+      prepare_screenshot_directory
+      driver.start_session
     end
   end
 
@@ -65,35 +27,12 @@ class LuckyFlow::Server
     LuckyFlow.settings.screenshot_directory
   end
 
-  private def browser_binary
-    LuckyFlow.settings.browser_binary
-  end
-
-  private def capabilities
-    if browser_binary.nil?
-      CAPABILITIES
-    else
-      CAPABILITIES.merge({
-        chromeOptions: {
-          args:   CAPABILITIES[:chromeOptions][:args],
-          binary: browser_binary,
-        },
-      })
-    end
-  end
-
   def reset
     @session.try &.cookie_manager.delete_all_cookies
   end
 
   def shutdown
     @session.try &.delete
-    @driver.try &.stop
-  end
-
-  private def driver_path
-    LuckyFlow.settings.chromedriver_path || Webdrivers::Chromedriver.install
-  rescue err
-    raise DriverInstallationError.new(err)
+    @driver.stop
   end
 end


### PR DESCRIPTION
Fixes #110

The headless configuration was hard-coded. This extracts the headless chrome configuration into its own class. It also extracts a base `LuckyFlow::Driver` class for other browser support to be added in the future. `LuckyFlow::Drivers::Chrome` was also added which is the base for the headless browser. Updating the value in `LuckyFlow::Server#driver` to use the base chrome driver will run the specs with the browser GUI.

This completes a significant portion of https://github.com/luckyframework/lucky_flow/issues/91 as well. The main thing left is that there is chrome-specific naming in the configuration of LuckyFlow, like [`chromedriver_path`](https://github.com/luckyframework/lucky_flow/blob/45f52fa135f89ea6487e5f0d646664e8a0f70cce/src/lucky_flow.cr#L19), that need to be udpated. Setting `LuckyFlow::Server#driver` through configuration will also need to be added.

This should cause no breakages since this is all internal.