### PR TITLE
Refactor to support other browsers for testing

### DIFF
--- a/src/lucky_flow.cr
+++ b/src/lucky_flow.cr
@@ -16,8 +16,9 @@ class LuckyFlow
     setting base_uri : String
     setting retry_delay : Time::Span = 10.milliseconds
     setting stop_retrying_after : Time::Span = 1.second
-    setting chromedriver_path : String?
+    setting driver_path : String?
     setting browser_binary : String? = nil
+    setting driver : LuckyFlow::Driver.class = LuckyFlow::Drivers::HeadlessChrome
   end
 
   def visit(path : String)

--- a/src/lucky_flow.cr
+++ b/src/lucky_flow.cr
@@ -21,6 +21,10 @@ class LuckyFlow
     setting driver : LuckyFlow::Driver.class = LuckyFlow::Drivers::HeadlessChrome
   end
 
+  def HabitatSettings.chromedriver_path=(_chromedriver_path)
+    {% raise "'chromedriver_path' has been renamed to 'driver_path'" %}
+  end
+
   def visit(path : String)
     session.navigate_to("#{settings.base_uri}#{path}")
   end

--- a/src/lucky_flow/drivers/chrome.cr
+++ b/src/lucky_flow/drivers/chrome.cr
@@ -23,7 +23,7 @@ abstract class LuckyFlow::Drivers::Chrome < LuckyFlow::Driver
   end
 
   private def driver_path
-    LuckyFlow.settings.chromedriver_path || Webdrivers::Chromedriver.install
+    LuckyFlow.settings.driver_path || Webdrivers::Chromedriver.install
   rescue err
     raise DriverInstallationError.new(err)
   end

--- a/src/lucky_flow/errors.cr
+++ b/src/lucky_flow/errors.cr
@@ -19,14 +19,14 @@ class LuckyFlow
   class DriverInstallationError < Error
     def initialize(error : Exception)
       message = <<-ERROR
-      Something went wrong while installing Chromedriver:
+      Something went wrong while installing the web driver:
 
         #{error}
 
-      If you'd like to manually install Chromedriver yourself, make sure to tell LuckyFlow where it is located:
+      If you'd like to manually install the web driver yourself, make sure to tell LuckyFlow where it is located:
 
         LuckyFlow.configure do |settings|
-          settings.chromedriver_path = "/path/to/chromedriver"
+          settings.driver_path = "/path/to/webdriver"
         end
       ERROR
 

--- a/src/lucky_flow/server.cr
+++ b/src/lucky_flow/server.cr
@@ -4,7 +4,7 @@ class LuckyFlow::Server
   INSTANCE = new
 
   @session : Selenium::Session?
-  private getter driver : LuckyFlow::Driver = LuckyFlow::Drivers::HeadlessChrome.new
+  private getter driver : LuckyFlow::Driver = LuckyFlow.settings.driver.new
 
   # Use LuckyFlow::Server::INSTANCE instead
   private def initialize


### PR DESCRIPTION
Fixes #91

Allows setting any available `LuckyFlow::Driver` for testing. We currently support these drivers:
- `LuckyFlow::Drivers::Chrome`
- `LuckyFlow::Drivers::HeadlessChrome`

We can potentially support any drivers that our [selenium](https://github.com/matthewmcgarvey/selenium.cr) library supports.

**BREAKING CHANGE**
The change is minor but the `chromedriver_path` setting was renamed to `driver_path` to avoid chrome-specific naming.