### PR TITLE
Add back support for browser_binary setting

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -11,7 +11,7 @@ license: MIT
 dependencies:
   selenium:
     github: matthewmcgarvey/selenium.cr
-    version: ~> 0.8.0
+    version: ~> 0.9.0
   webdrivers:
     github: matthewmcgarvey/webdrivers.cr
     version: ~> 0.3.0

--- a/src/lucky_flow/drivers/chrome.cr
+++ b/src/lucky_flow/drivers/chrome.cr
@@ -1,5 +1,8 @@
 abstract class LuckyFlow::Drivers::Chrome < LuckyFlow::Driver
   def start_session : Selenium::Session
+    capabilities = Selenium::Chrome::Capabilities.new
+    capabilities.chrome_options.args = args
+    capabilities.chrome_options.binary = browser_binary
     driver.create_session(capabilities)
   rescue e : IO::Error
     retry_start_session(e)
@@ -9,8 +12,8 @@ abstract class LuckyFlow::Drivers::Chrome < LuckyFlow::Driver
     @driver.try(&.stop)
   end
 
-  protected def capabilities
-    Selenium::Chrome::Capabilities.new
+  protected def args : Array(String)
+    [] of String
   end
 
   @driver : Selenium::Driver?
@@ -26,5 +29,9 @@ abstract class LuckyFlow::Drivers::Chrome < LuckyFlow::Driver
     LuckyFlow.settings.driver_path || Webdrivers::Chromedriver.install
   rescue err
     raise DriverInstallationError.new(err)
+  end
+
+  private def browser_binary : String?
+    LuckyFlow.settings.browser_binary
   end
 end

--- a/src/lucky_flow/drivers/headless_chrome.cr
+++ b/src/lucky_flow/drivers/headless_chrome.cr
@@ -1,8 +1,5 @@
 class LuckyFlow::Drivers::HeadlessChrome < LuckyFlow::Drivers::Chrome
-  protected def capabilities
-    capabilities = super
-    capabilities.args(["no-sandbox", "headless", "disable-gpu"])
-
-    capabilities
+  protected def args : Array(String)
+    ["no-sandbox", "headless", "disable-gpu"]
   end
 end


### PR DESCRIPTION
Fixes #111 

Updating to v0.9.0 of selenium.cr allows us to configure the browser_binary path again.