### PR TITLE
Add way to pause flow

### DIFF
--- a/src/lucky_flow.cr
+++ b/src/lucky_flow.cr
@@ -183,6 +183,11 @@ class LuckyFlow
     session.alert_manager.dismiss_alert
   end
 
+  def pause
+    puts "\nPausing to debug... (press enter to continue)"
+    STDIN.gets
+  end
+
   def session
     self.class.session
   end


### PR DESCRIPTION
Fixes #27

This is only meant to be used when running with the browser showing and not headless.

Can't really write a spec for this method.