### PR TITLE
Fix issues with new driver setup

### DIFF
--- a/src/lucky_flow/drivers/chrome.cr
+++ b/src/lucky_flow/drivers/chrome.cr
@@ -1,4 +1,4 @@
-abstract class LuckyFlow::Drivers::Chrome < LuckyFlow::Driver
+class LuckyFlow::Drivers::Chrome < LuckyFlow::Driver
   def start_session : Selenium::Session
     capabilities = Selenium::Chrome::Capabilities.new
     capabilities.chrome_options.args = args

--- a/src/lucky_flow/server.cr
+++ b/src/lucky_flow/server.cr
@@ -4,7 +4,7 @@ class LuckyFlow::Server
   INSTANCE = new
 
   @session : Selenium::Session?
-  private getter driver : LuckyFlow::Driver = LuckyFlow.settings.driver.new
+  @driver : LuckyFlow::Driver?
 
   # Use LuckyFlow::Server::INSTANCE instead
   private def initialize
@@ -33,6 +33,12 @@ class LuckyFlow::Server
 
   def shutdown
     @session.try &.delete
-    @driver.stop
+    @driver.try &.stop
+  end
+
+  private def driver
+    @driver ||= begin
+      LuckyFlow.settings.driver.new
+    end
   end
 end


### PR DESCRIPTION
Fixes #118

The problem was that since the server is created in a constant it was retrieving the driver setting before the `spec_helper` was able to configure it. https://github.com/luckyframework/lucky_flow/blob/ff7c22d3c72365ededf7bc677669ed95264c2f37/src/lucky_flow/server.cr#L4

I also think I found a bug with Crystal. I was able to run the specs with the `LuckyFlow::Drivers::Chrome` while it was still abstract. The only reason I saw the problem was that I was experimenting with the habitat settings taking in a driver instance instead of the driver class.