### PR TITLE
Pass error along as cause instead of using message only

### DIFF
--- a/src/lucky_flow/errors.cr
+++ b/src/lucky_flow/errors.cr
@@ -19,9 +19,7 @@ class LuckyFlow
   class DriverInstallationError < Error
     def initialize(error : Exception)
       message = <<-ERROR
-      Something went wrong while installing the web driver:
-
-        #{error}
+      Something went wrong while installing the web driver
 
       If you'd like to manually install the web driver yourself, make sure to tell LuckyFlow where it is located:
 
@@ -30,7 +28,7 @@ class LuckyFlow
         end
       ERROR
 
-      super message
+      super message, cause: error
     end
   end
 


### PR DESCRIPTION
Fixes #123

Instead of taking the wrapped error's message and placing it in a new message
let's set the error as this wrapping error's cause and take the underlying error
message out since it will be displayed in the backtrace.