### PR TITLE
Fix new ameba warnings

### DIFF
--- a/src/lucky_flow/error_message_when_not_found.cr
+++ b/src/lucky_flow/error_message_when_not_found.cr
@@ -50,9 +50,8 @@ class LuckyFlow::ErrorMessageWhenNotFound
 
   private def all_flow_ids : Array(String)
     session.find_elements(:css, "[flow-id]")
-      .map(&.attribute("flow-id"))
-      .compact
-      .uniq
+      .compact_map(&.attribute("flow-id"))
+      .uniq!
   end
 
   private def only_looking_for_flow_id? : Bool


### PR DESCRIPTION
The two changes ameba had us make:
- switch to using `compact_map`
- when chaining methods, use the bang version if there is one (`uniq` -> `uniq!`)