### PR TITLE
Fix handling of default driver

### DIFF
--- a/src/lucky_flow.cr
+++ b/src/lucky_flow.cr
@@ -13,8 +13,6 @@ class LuckyFlow
 
   @@driver : LuckyFlow::Driver?
 
-  class_property default_driver : String = "headless_chrome"
-
   Habitat.create do
     setting screenshot_directory : String = "./tmp/screenshots"
     setting base_uri : String
@@ -23,12 +21,16 @@ class LuckyFlow
     setting driver_path : String?
   end
 
+  def self.default_driver=(value : String)
+    LuckyFlow::Registry.default_driver = value
+  end
+
   def self.driver : LuckyFlow::Driver
-    @@driver ||= LuckyFlow::Registry.get_driver(self.default_driver)
+    @@driver ||= LuckyFlow::Registry.get_driver
   end
 
   def self.driver(name : String) : LuckyFlow::Driver
-    @@driver = LuckyFlow::Registry.get_driver(self.default_driver)
+    @@driver = LuckyFlow::Registry.get_driver(name)
   end
 
   def self.shutdown : Nil

--- a/src/lucky_flow/registry.cr
+++ b/src/lucky_flow/registry.cr
@@ -1,4 +1,6 @@
 class LuckyFlow::Registry
+  class_property default_driver : String = "headless_chrome"
+
   @@registry = Hash(String, Proc(LuckyFlow::Driver)).new
   @@running_registry = Hash(String, LuckyFlow::Driver).new
 
@@ -10,7 +12,7 @@ class LuckyFlow::Registry
     Set.new(@@registry.keys)
   end
 
-  def self.get_driver(name : String) : LuckyFlow::Driver
+  def self.get_driver(name : String = default_driver) : LuckyFlow::Driver
     @@running_registry[name] ||= @@registry[name].call
   end
 


### PR DESCRIPTION
Fixes #138

Two bugs fixed here:
- Calling `LuckyFlow.driver("blah")` did not actually use the "blah" driver, it always use the default one
- `LuckyFlow.default_driver=()` was not being inherited as it should have