### PR TITLE
Moving some methods to separate extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,24 @@ Then view the guides: https://luckyframework.org/guides/browser-tests/
 
 You should be ready to go!
 
+For use with some of the Lucky shards (including Lucky itself), you'll need
+to require a few extensions:
+
+```crystal
+# This extension adds an override to `visit` allowing you
+# to pass in a Lucky::Action.class or Lucky::RouteHelper
+require "lucky_flow/ext/lucky"
+
+# This extension adds a `fill_form` method that you can pass
+# an Operation or SaveOperation to which will populate form
+# fields for you
+require "lucky_flow/ext/avram"
+
+# Similar to the Lucky extension, this gives an additional override
+# to `visit` that allows you to visit a page as a specific User
+require "lucky_flow/ext/authentic"
+```
+
 ## Usage
 
 > Note that you can only pass string paths to `visit` since only Lucky has

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,6 +1,9 @@
 require "spec"
 require "http"
 require "../src/lucky_flow"
+require "../src/ext/lucky"
+require "../src/ext/avram"
+require "../src/ext/authentic"
 require "./support/**"
 
 include LuckyFlow::Expectations

--- a/src/ext/authentic.cr
+++ b/src/ext/authentic.cr
@@ -1,0 +1,25 @@
+# If you have [Authentic](https://github.com/luckyframework/authentic)
+# required, you can require this file for some additional helpers
+module AuthenticLuckyFlowHelpers
+  def visit(action : Lucky::Action.class, as user : User)
+    visit(action.route, as: user)
+  end
+
+  def visit(route_helper : Lucky::RouteHelper, as user : User)
+    url = route_helper.url
+    uri = URI.parse(url)
+    if uri.query
+      url += "&backdoor_user_id=#{user.id}"
+    elsif uri.query.nil?
+      url += "?backdoor_user_id=#{user.id}"
+    end
+    driver.visit(url)
+  end
+end
+
+# ```
+# require "lucky_flow/ext/authentic"
+# ```
+class LuckyFlow
+  include AuthenticLuckyFlowHelpers
+end

--- a/src/ext/avram.cr
+++ b/src/ext/avram.cr
@@ -1,0 +1,33 @@
+# If you have [Avram](https://github.com/luckyframework/avram)
+# required, you can require this file for some additional helpers
+module AvramLuckyFlowHelpers
+  # Fill a form created by Lucky that uses an Avram::SaveOperation
+  #
+  # Note that Lucky and Avram are required to use this method
+  #
+  # ```
+  # fill_form QuestionForm,
+  #   title: "Hello there!",
+  #   body: "Just wondering what day it is"
+  # ```
+  def fill_form(
+    form : Avram::SaveOperation.class | Avram::Operation.class,
+    **fields_and_values
+  )
+    fields_and_values.each do |name, value|
+      element = field("#{form.param_key}:#{name}")
+      if element.tag_name == "select"
+        self.select(element, value.to_s)
+      else
+        self.fill(element, with: value)
+      end
+    end
+  end
+end
+
+# ```
+# require "lucky_flow/ext/avram"
+# ```
+class LuckyFlow
+  include AvramLuckyFlowHelpers
+end

--- a/src/ext/lucky.cr
+++ b/src/ext/lucky.cr
@@ -1,0 +1,19 @@
+# If you have [Lucky](https://github.com/luckyframework/lucky)
+# required, you can require this file for some additional helpers
+module LuckyActionLuckyFlowHelpers
+  def visit(action : Lucky::Action.class)
+    visit(action.route)
+  end
+
+  def visit(route_helper : Lucky::RouteHelper)
+    url = route_helper.url
+    driver.visit(url)
+  end
+end
+
+# ```
+# require "lucky_flow/ext/lucky"
+# ```
+class LuckyFlow
+  include LuckyActionLuckyFlowHelpers
+end

--- a/src/lucky_flow.cr
+++ b/src/lucky_flow.cr
@@ -49,21 +49,6 @@ class LuckyFlow
     driver.visit("#{settings.base_uri}#{path}")
   end
 
-  def visit(action : Lucky::Action.class, as user : User? = nil)
-    visit(action.route, as: user)
-  end
-
-  def visit(route_helper : Lucky::RouteHelper, as user : User? = nil)
-    url = route_helper.url
-    uri = URI.parse(url)
-    if uri.query && user
-      url += "&backdoor_user_id=#{user.id}"
-    elsif uri.query.nil? && user
-      url += "?backdoor_user_id=#{user.id}"
-    end
-    driver.visit(url)
-  end
-
   def open_screenshot(process = Process, time = Time.utc, fullsize = false) : Void
     filename = generate_screenshot_filename(time)
     take_screenshot(filename, fullsize)
@@ -151,29 +136,6 @@ class LuckyFlow
 
   def select(element : Element, value : Array(String))
     element.select_options(value)
-  end
-
-  # Fill a form created by Lucky that uses an Avram::SaveOperation
-  #
-  # Note that Lucky and Avram are required to use this method
-  #
-  # ```
-  # fill_form QuestionForm,
-  #   title: "Hello there!",
-  #   body: "Just wondering what day it is"
-  # ```
-  def fill_form(
-    form : Avram::SaveOperation.class | Avram::Operation.class,
-    **fields_and_values
-  )
-    fields_and_values.each do |name, value|
-      element = field("#{form.param_key}:#{name}")
-      if element.tag_name == "select"
-        self.select(element, value.to_s)
-      else
-        self.fill(element, with: value)
-      end
-    end
   end
 
   def el(css_selector : String, text : String) : LuckyFlow::Element


### PR DESCRIPTION
Fixes #65

This breaks out the methods that require Lucky, Avram, or Authentic being required. Now you would just require the specific extension you need.

For most apps, it's an easy change:

```crystal
# spec/spec_helper.cr
require "spec"
require "lucky_flow"
# Add these 3 lines
require "lucky_flow/ext/lucky"
require "lucky_flow/ext/avram"
require "lucky_flow/ext/authentic"
```

If you're using Lucky, but without Avram or Authentic, just add the require for lucky.

Another PR will need to go up to LuckyCLI to include these. I'll open that next.
