### PR TITLE
Fix race conditions(?)

### DIFF
--- a/src/lucky_flow.cr
+++ b/src/lucky_flow.cr
@@ -45,6 +45,23 @@ class LuckyFlow
     LuckyFlow::Registry.current_driver.try(&.reset)
   end
 
+  def self.wait_for_server(timeout : Time::Span = 5.seconds)
+    uri = URI.parse(settings.base_uri)
+    host = uri.host || "127.0.0.1"
+    port = uri.port || 3000
+    retry_interval = 100.milliseconds
+    retries = (timeout / retry_interval).to_i
+
+    retries.times do
+      TCPSocket.open(host, port) { }
+      return
+    rescue IO::Error
+      sleep(retry_interval)
+    end
+
+    raise "Server at #{host}:#{port} did not start within #{timeout}"
+  end
+
   def visit(path : String)
     driver.visit("#{settings.base_uri}#{path}")
   end

--- a/src/lucky_flow/find_element.cr
+++ b/src/lucky_flow/find_element.cr
@@ -44,13 +44,16 @@ class LuckyFlow::FindElement
   private def find_matching_elements : Array(LuckyFlow::Element)
     self.tries += 1
     driver.find_css(selector).select do |element|
-      text_to_check_for = inner_text
-      if text_to_check_for
+      if text_to_check_for = inner_text
         element.text.includes?(text_to_check_for)
       else
         true
       end
     end
+  rescue ex : ::Selenium::Error
+    raise ex unless ex.message.try(&.includes?("stale element"))
+
+    [] of LuckyFlow::Element
   end
 
   private def raise_element_not_found_error

--- a/src/lucky_flow/selenium/driver.cr
+++ b/src/lucky_flow/selenium/driver.cr
@@ -16,6 +16,18 @@ abstract class LuckyFlow::Selenium::Driver < LuckyFlow::Driver
 
   def visit(url : String)
     session.navigate_to(url)
+    wait_for_ready
+  end
+
+  private def wait_for_ready
+    retry_interval = 10.milliseconds
+    retries = (LuckyFlow.settings.stop_retrying_after / retry_interval).to_i
+    retries.times do
+      ready = session.document_manager.execute_script("return document.readyState;")
+      return if ready == "complete"
+
+      sleep(retry_interval)
+    end
   end
 
   def window_size : NamedTuple(width: Int64?, height: Int64?)

--- a/src/lucky_flow/selenium/driver.cr
+++ b/src/lucky_flow/selenium/driver.cr
@@ -82,7 +82,10 @@ abstract class LuckyFlow::Selenium::Driver < LuckyFlow::Driver
   end
 
   def reset : Nil
-    @session.try &.cookie_manager.delete_all_cookies
+    @session.try do |session|
+      session.navigate_to("about:blank")
+      session.cookie_manager.delete_all_cookies
+    end
   end
 
   def stop

--- a/src/lucky_flow/selenium/driver.cr
+++ b/src/lucky_flow/selenium/driver.cr
@@ -1,5 +1,6 @@
 abstract class LuckyFlow::Selenium::Driver < LuckyFlow::Driver
-  @retry_limit : Time = 2.seconds.from_now
+  SESSION_RETRY_LIMIT = 2.seconds
+
   @driver : ::Selenium::Driver?
   @capabilities : ::Selenium::Capabilities
 
@@ -82,18 +83,16 @@ abstract class LuckyFlow::Selenium::Driver < LuckyFlow::Driver
   end
 
   private def start_session : ::Selenium::Session
-    driver.create_session(@capabilities)
-  rescue e : IO::Error
-    retry_start_session(e)
-  end
+    retry_interval = 100.milliseconds
+    retries = (SESSION_RETRY_LIMIT / retry_interval).to_i
 
-  private def retry_start_session(e)
-    if Time.utc <= @retry_limit
-      sleep(100.milliseconds)
-      start_session
-    else
-      raise e
+    retries.times do
+      return driver.create_session(@capabilities)
+    rescue IO::Error
+      sleep(retry_interval)
     end
+
+    driver.create_session(@capabilities)
   end
 
   private def find_elements(


### PR DESCRIPTION
I'm mildly optimistic about this update. I haven't seen any errors so far.

## `SESSION_RETRY_LIMIT`
The biggest issue I think was the `@retry_limit` instance variable in the selenium driver class. Any delays in the setup, after initialization and before the actual tests were run, would eat into the time span. Now the full time span is considered.

## The `wait_for_ready` method
Waits for the DOM to be ready. That's just a precaution,

## Navigate to `about:blank` on reset
Just to make sure no remnants of the previous test are left. Essentially always starting with a blank slate.

## `LuckyFlow.wait_for_server`
This is a small addition to apps to make sure the app's http server is ready to receive requests. So the `spec/setup/start_app_server.cr` file now looks like:

```crystal
app_server = AppServer.new

spawn do
  app_server.listen
end

LuckyFlow.wait_for_server

Spec.after_suite do
  LuckyFlow.shutdown
  app_server.close
end
```

