### PR TITLE
Fix element not found error

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,6 @@ View guide at: https://luckyframework.org/guides/browser-tests/
 - Run Ameba `./bin/ameba`
 - Run specs `crystal spec` (or via docker with `./script/setup` and `./script/test`)
 
-> [!NOTE]
-> When running `crystal spec` on non-US systems, the custom date spec will
-> fail. To work around this issue on Ubuntu for example, run:
->
-> `LANG=en_US.UTF-8 LC_TIME=en_US.UTF-8 crystal spec`
-
 ## Contributing
 
 1. Fork it ( https://github.com/luckyframework/lucky_flow/fork )

--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ View guide at: https://luckyframework.org/guides/browser-tests/
 - Run Ameba `./bin/ameba`
 - Run specs `crystal spec` (or via docker with `./script/setup` and `./script/test`)
 
+> [!NOTE]
+> When running `crystal spec` on non-US systems, the custom date spec will
+> fail. To work around this issue on Ubuntu for example, run:
+>
+> `LANG=en_US.UTF-8 LC_TIME=en_US.UTF-8 crystal spec`
+
 ## Contributing
 
 1. Fork it ( https://github.com/luckyframework/lucky_flow/fork )

--- a/src/lucky_flow.cr
+++ b/src/lucky_flow.cr
@@ -17,7 +17,7 @@ class LuckyFlow
     setting screenshot_directory : String = "./tmp/screenshots"
     setting base_uri : String
     setting retry_delay : Time::Span = 10.milliseconds
-    setting stop_retrying_after : Time::Span = 1.second
+    setting stop_retrying_after : Time::Span = 3.seconds
     setting driver_path : String?
   end
 

--- a/src/lucky_flow/selenium/chrome/driver.cr
+++ b/src/lucky_flow/selenium/chrome/driver.cr
@@ -24,6 +24,7 @@ end
 
 LuckyFlow::Registry.register :headless_chrome do
   LuckyFlow::Selenium::Chrome::Driver.new do |config|
+    ENV["LC_ALL"] = "en_US.UTF-8"
     remote_debugging_port = ENV.fetch("CHROME_REMOTE_DEBUGGING_PORT", "9222")
     config.chrome_options.args = [
       "--no-sandbox",

--- a/src/lucky_flow/selenium/driver.cr
+++ b/src/lucky_flow/selenium/driver.cr
@@ -15,6 +15,7 @@ abstract class LuckyFlow::Selenium::Driver < LuckyFlow::Driver
   end
 
   def visit(url : String)
+    session.document_manager.execute_script("window.__lucky_flow_pending = true;") if @session
     session.navigate_to(url)
     wait_for_ready
   end
@@ -22,10 +23,10 @@ abstract class LuckyFlow::Selenium::Driver < LuckyFlow::Driver
   private def wait_for_ready
     retry_interval = 10.milliseconds
     retries = (LuckyFlow.settings.stop_retrying_after / retry_interval).to_i
-    retries.times do
-      ready = session.document_manager.execute_script("return document.readyState;")
-      return if ready == "complete"
+    script = "return !window.__lucky_flow_pending && document.readyState === 'complete';"
 
+    retries.times do
+      return if session.document_manager.execute_script(script) == "true"
       sleep(retry_interval)
     end
   end


### PR DESCRIPTION
In reply to: https://github.com/luckyframework/lucky_cli/issues/883#issuecomment-4300597572

This PR includes two tweaks.

## 1. Increase retry timeout
I bumped it from `1` to `3` seconds so there's just a bit more time for everything to become alive, without too much impact.

## 2. Ensure `readyState` check happens in a new document
The `readyState` check I added before was only partially effective because `readyState === 'complete'` could still be true for the previous page right after a `navigate_to`.
Now, before each visit a marker is set on the previous page's window. After navigating we wait until both the marker is gone and `readyState === 'complete'`.


I also added a small note in the README on how to test on non-US systems. Always had one test failing because of a date formatting mismatch.